### PR TITLE
Modify alpha by reference

### DIFF
--- a/AWLThemeManager/AWLThemeManager.m
+++ b/AWLThemeManager/AWLThemeManager.m
@@ -98,7 +98,11 @@
 {
     if ([self isValidString:colorValue]) {
         NSArray* array = [colorValue componentsSeparatedByString:@","];
-        if (array && [array count] == 4) {
+        if (array && [array count] == 2) {
+            return [UIColor colorWithWhite:[array[0] floatValue]
+                                     alpha:[array[1] floatValue]];
+        }
+        else if (array && [array count] == 4) {
             return [UIColor colorWithRed:[array[0] floatValue]/255
                                    green:[array[1] floatValue]/255
                                     blue:[array[2] floatValue]/255

--- a/AWLThemeManager/AWLThemeManager.m
+++ b/AWLThemeManager/AWLThemeManager.m
@@ -88,7 +88,12 @@
     NSString *colorValue = [self objectForKey:key forTheme:themeName];
     UIColor *color = [self colorFromString:colorValue];
     if (color == nil && [self isValidString:colorValue]) {
+        NSArray* referenceColor = [colorValue componentsSeparatedByString: @":"];
+        colorValue = referenceColor.firstObject;
         color = [self colorForKey:colorValue forTheme:themeName];
+        if (referenceColor.count > 1) {
+            color = [color colorWithAlphaComponent: [referenceColor[1] floatValue]];
+        }
     }
     
     return color;


### PR DESCRIPTION
if you reference a color, e.g. “COLOR1”  = “255,0,0,1”, “COLOR2” =
“COLOR1” you can now append “:[alpha]” to the reference to modify it’s
alpha, e.g. “COLOR2” = “COLOR1:0.2” will equate to “255,0,0,0.2”
