### PR TITLE
Support compiled xcasset files

### DIFF
--- a/AWLThemeManager/AWLThemeManager.m
+++ b/AWLThemeManager/AWLThemeManager.m
@@ -129,10 +129,31 @@
         return nil;
     }
     
-    NSString *path = self.themeList[themeName];
-    path = [self relativePathToMainBundle:path];
-    NSString *filePath = [path stringByAppendingPathComponent:imgName];
-    UIImage *img = [UIImage imageNamed:filePath];
+    UIImage*  img    = nil;
+    NSBundle* bundle = [NSBundle bundleWithPath: self.themeList[themeName]];
+    
+    if (NSFoundationVersionNumber >= NSFoundationVersionNumber_iOS_8_0) {
+        img = [UIImage imageNamed: imgName inBundle: bundle compatibleWithTraitCollection: nil];
+    }
+    else {
+#ifdef AWLThemeManager_XCASSETS_iOS7
+        //This is included for reference/completeness. It fetches the device specific
+        //image from the compiled Assets.car embedded in the theme bundle for iOS7 devices.
+        //However, it is a *PRIVATE API*
+        //As such, all relevant warnings and caveats apply to it's usage
+        //IF you want to enable with cocoapods you'll need this:
+        //https://guides.cocoapods.org/syntax/podfile.html#post_install
+        static NSString* iOS7PrivateCompatSelector = @"_" @"device" @"Specific" @"ImageNamed:" @"inBundle:";
+        img = [UIImage performSelector: NSSelectorFromString(iOS7PrivateCompatSelector) withObject: imgName withObject: bundle];
+#endif
+    }
+    
+    if (img == nil) {
+        NSString *path = self.themeList[themeName];
+        path = [self relativePathToMainBundle:path];
+        NSString *filePath = [path stringByAppendingPathComponent:imgName];
+        img = [UIImage imageNamed:filePath];
+    }
     
     if (img == nil) {
         NSString *baseTheme = self.themeRelationship[themeName];


### PR DESCRIPTION
Add support for compiled xcasset files (Assets.car) in theme bundles.

Note:
The bundle needs to be an actual OS X bundle target in the project with
it's SDK set to iOS & a valid info.plist in order for Xcode to compile
the .xcassets file inside it
