### PR TITLE
Support keyed images

### DIFF
--- a/AWLThemeManager/AWLThemeManager.h
+++ b/AWLThemeManager/AWLThemeManager.h
@@ -25,6 +25,10 @@
 - (UIFont*)fontForKey:(NSString*)key;
 - (UIFont *)fontForKey:(NSString *)key forTheme:(NSString*)themeName;
 
+//Get img name from defaults.plist, and then img from theme bundle
+- (UIImage *)imageforKey:(NSString *)key;
+- (UIImage *)imageforKey:(NSString *)key forTheme:(NSString*)themeName;
+
 //Get img from theme bundle
 - (UIImage*)imageNamed:(NSString*)imgName;
 - (UIImage *)imageNamed:(NSString *)imgName forTheme:(NSString*)themeName;

--- a/AWLThemeManager/AWLThemeManager.m
+++ b/AWLThemeManager/AWLThemeManager.m
@@ -131,6 +131,9 @@
     
     NSString *imageName = [self objectForKey:key forTheme:themeName];
     
+    if (imageName == nil) {
+        imageName = key;
+    }    
     return [self imageNamed:imageName forTheme:themeName];
 }
 

--- a/AWLThemeManager/AWLThemeManager.m
+++ b/AWLThemeManager/AWLThemeManager.m
@@ -118,6 +118,22 @@
     return nil;
 }
 
+- (UIImage *)imageforKey:(NSString *)key
+{
+    return [self imageforKey:key forTheme:self.currentTheme];;
+}
+
+- (UIImage *)imageforKey:(NSString *)key forTheme:(NSString*)themeName
+{
+    if ([self isValidString:themeName] == NO || [self isValidString:key] == NO) {
+        return nil;
+    }
+    
+    NSString *imageName = [self objectForKey:key forTheme:themeName];
+    
+    return [self imageNamed:imageName forTheme:themeName];
+}
+
 - (UIImage *)imageNamed:(NSString *)imgName
 {
     return [self imageNamed:imgName forTheme:self.currentTheme];;

--- a/AWLThemeManager/AWLThemeManager.m
+++ b/AWLThemeManager/AWLThemeManager.m
@@ -129,10 +129,31 @@
         return nil;
     }
     
-    NSString *path = self.themeList[themeName];
-    path = [self relativePathToMainBundle:path];
-    NSString *filePath = [path stringByAppendingPathComponent:imgName];
-    UIImage *img = [UIImage imageNamed:filePath];
+    UIImage*  img    = nil;
+    NSBundle* bundle = [NSBundle bundleWithPath: self.themeList[themeName]];
+    
+    if (NSFoundationVersionNumber >= NSFoundationVersionNumber_iOS_8_0) {
+        img = [UIImage imageNamed: imgName inBundle: bundle compatibleWithTraitCollection: nil];
+    }
+    else {
+#ifdef AWLThemeManager_XCASSETS_iOS7
+        //This is included for reference/completeness. It fetches the device specific
+        //image from the compiled Assets.car embedded in the theme bundle for iOS7 devices.
+        //However, it is a *PRIVATE API*
+        //As such, all relevant warnings and caveats apply to it's usage
+        //IF you want to enable with cocoapods you'll need this:
+        //https://guides.cocoapods.org/syntax/podfile.html#post_install
+        static NSString* iOS7PrivateCompatSelector = @"_" @"device" @"Specific" @"ImageNamed:" @"inBundle:";
+        img = [UIImage performSelector: NSSelectorFromString(iOS7PrivateCompatSelector) withObject: imgName withObject: bundle];
+#endif
+    }
+    
+    if (img == nil) {
+        NSString *path = self.themeList[themeName];
+        path = [self relativePathToMainBundle:path];
+        NSString *filePath = [path stringByAppendingPathComponent:imgName];
+        img = [UIImage imageNamed:filePath];
+    }
     
     if (img == nil) {
         NSString *baseTheme = self.themeRelationship[themeName];


### PR DESCRIPTION
Currently you can override image "foo" (foo.png) in Bundle A with
foo.png in Bundle B.

However, sometimes you need to override image "foo" (foo.png) in Bundle
A with quack.png in Bundle B. Basically you want to request imageNamed:
"Foo", but have the theme swap that out for "Quack" via the plist, and
then try to find imageNamed: "Quack" instead.
