### PR TITLE
Display name for theme

### DIFF
--- a/AWLThemeManager/AWLThemeManager.h
+++ b/AWLThemeManager/AWLThemeManager.h
@@ -12,10 +12,13 @@
 @interface AWLThemeManager : NSObject
 
 @property (nonatomic, strong) NSString *currentTheme;
+@property (nonatomic, strong) NSString *currentThemeDisplayName;
 
 // return themeName
 - (NSString*)addTheme:(NSString*)themePath;
 - (NSArray*)allThemes;
+
+- (NSString*)displayNameForTheme:(NSString*)themeName;
 
 //Get color from defaults.plist
 - (UIColor*)colorForKey:(NSString*)key;

--- a/AWLThemeManager/AWLThemeManager.m
+++ b/AWLThemeManager/AWLThemeManager.m
@@ -103,7 +103,7 @@
     }
     
     NSString *colorValue = [self objectForKey:key forTheme:themeName];
-    UIColor *color = [self colorFromString:colorValue];
+    UIColor *color = [self colorFromString:colorValue forTheme: themeName];
     if (color == nil && [self isValidString:colorValue]) {
         NSArray* referenceColor = [colorValue componentsSeparatedByString:@":"];
         colorValue = referenceColor.firstObject;
@@ -116,9 +116,23 @@
     return color;
 }
 
-- (UIColor*)colorFromString:(NSString*)colorValue
+- (UIColor*)colorFromString:(NSString*)colorValue forTheme:(NSString *)themeName
 {
     if ([self isValidString:colorValue]) {
+        
+        if ([colorValue hasPrefix: @"#"]) {
+            NSArray*  array       = [colorValue componentsSeparatedByString:@","];
+            NSString* patternName = [array[0] substringFromIndex:1];
+            UIImage* patternImage = [self imageNamed:patternName forTheme:themeName];
+            if (patternImage == nil) {
+                return nil;
+            }
+            UIColor* color = [UIColor colorWithPatternImage: patternImage];
+            if (array.count == 2) {
+                color = [color colorWithAlphaComponent: [array[1] doubleValue]];
+            }
+            return color;
+        }
         NSArray* array = [colorValue componentsSeparatedByString:@","];
         if (array && [array count] == 2) {
             return [UIColor colorWithWhite:[array[0] doubleValue]

--- a/AWLThemeManager/AWLThemeManager.m
+++ b/AWLThemeManager/AWLThemeManager.m
@@ -18,6 +18,8 @@
 
 @implementation AWLThemeManager
 
+@dynamic currentThemeDisplayName;
+
 - (instancetype)init
 {
     self = [super init];
@@ -72,6 +74,21 @@
 - (NSArray *)allThemes
 {
     return [self.themeList allKeys];
+}
+
+- (NSString*) currentThemeDisplayName
+{
+    return [self displayNameForTheme: self.currentTheme];
+}
+
+- (NSString*)displayNameForTheme:(NSString*)themeName
+{
+    NSString* displayName = [self objectForKey:@"AWL_THEME_DISPLAYNAME" forTheme:themeName];
+    if (displayName == nil) {
+        displayName = themeName;
+    }
+
+    return displayName;
 }
 
 - (UIColor *)colorForKey:(NSString *)key


### PR DESCRIPTION
Added “AWL_THEME_DISPLAYNAME” which corresponds to the display name for bundle to decouple the theme name (defacto id) from something that can be
localized & displayed to the user.
