### PR TITLE
Support hex colors

### DIFF
--- a/AWLThemeManager.podspec
+++ b/AWLThemeManager.podspec
@@ -121,4 +121,6 @@ Pod::Spec.new do |s|
   # s.xcconfig = { "HEADER_SEARCH_PATHS" => "$(SDKROOT)/usr/include/libxml2" }
   # s.dependency "JSONKit", "~> 1.4"
 
+  s.dependency "UIColor-HexString"
+  
 end

--- a/AWLThemeManager/AWLThemeManager.m
+++ b/AWLThemeManager/AWLThemeManager.m
@@ -7,6 +7,7 @@
 //
 
 #import "AWLThemeManager.h"
+#import <UIColor+HexString.h>
 
 @interface AWLThemeManager ()
 
@@ -103,7 +104,7 @@
 {
     if ([self isValidString:colorValue]) {
         
-        if ([colorValue hasPrefix: @"#"]) {
+        if ([colorValue hasPrefix: @"@"]) {
             NSArray*  array       = [colorValue componentsSeparatedByString:@","];
             NSString* patternName = [array[0] substringFromIndex:1];
             UIImage* patternImage = [self imageNamed:patternName];
@@ -116,6 +117,10 @@
             }
             return color;
         }
+        else if ([colorValue hasPrefix: @"#"]) {
+            return [UIColor colorWithHexString: colorValue];
+        }
+        
         NSArray* array = [colorValue componentsSeparatedByString:@","];
         if (array && [array count] == 2) {
             return [UIColor colorWithWhite:[array[0] doubleValue]


### PR DESCRIPTION
Specify colors in hex format as:
# RGB
# ARGB
# RRGGBB
# AARRGGBB

Also changed the image pattern prefix from “#” to “@”
